### PR TITLE
feat: Refine work day summaries and location breakdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,11 @@ A web-based application to track worked days (by location), vacation days, and t
 *   Categorize entries as "Work Land" (with Country), "Work Ship" (with Ship Name), "Vacation", or "Traveling".
 *   Country input for "Work Land" is a filterable dropdown.
 *   View summaries:
-    *   Total worked days (calculated from date ranges).
-    *   Total vacation days (calculated from date ranges).
-    *   Total travel days (calculated from date ranges).
-    *   Breakdown of worked days by location (Country or Ship Name).
+    *   Total Worked Days - Land (calculated from date ranges).
+    *   Total Worked Days - Ship (calculated from date ranges).
+    *   Total Vacation Days (calculated from date ranges).
+    *   Total Travel Days (calculated from date ranges).
+    *   Breakdown of "Work Land" days by Country.
 *   View a log of all entries, showing date ranges.
 *   Edit existing entries.
 *   Delete existing entries (with confirmation).
@@ -71,10 +72,11 @@ A web-based application to track worked days (by location), vacation days, and t
     *   If "Work Land" is selected, a "Country" field will appear. Select or type to filter and choose a country. This field is required.
     *   If "Work Ship" is selected, a "Ship Name" field will appear. Enter the name of the ship. This field is required.
     *   Click "Add Entry". Each submission creates a single entry, even for date ranges.
-3.  **Viewing Entries:**
+3.  **Viewing Entries & Summaries:**
     *   The log displays entries with their date ranges.
-    *   Summaries calculate total days based on the duration of these entered ranges.
-    *   The "Location" column in summaries and logs will show the Country for "Work Land" entries or the Ship Name for "Work Ship" entries.
+    *   Summaries provide totals for "Worked Days - Land", "Worked Days - Ship", "Vacation Days", and "Travel Days".
+    *   A specific breakdown table shows "Work Land Days by Country".
+    *   The "Location/Details" column in the main log will show the Country for "Work Land" entries or the Ship Name for "Work Ship" entries.
 4.  **Editing Entries:**
     *   Click the "Edit" button next to an entry in the log.
     *   You will be taken to an edit page with the entry's details pre-filled.

--- a/app/routes.py
+++ b/app/routes.py
@@ -66,29 +66,34 @@ def index():
     # For GET request, fetch entries and calculate summaries
     entries = TimeEntry.query.order_by(TimeEntry.start_date.desc()).all()
 
-    total_worked_days = 0
+    total_work_land_days = 0
+    total_work_ship_days = 0
     total_vacation_days = 0
     total_travel_days = 0
-    work_days_by_location = {} # Stores total days (duration) per location
+    work_land_days_by_country = {} # Specific for work_land entries
 
     for entry in entries:
         # Calculate duration of the entry
         duration = (entry.end_date - entry.start_date).days + 1
 
-        if entry.entry_type == 'work_land' or entry.entry_type == 'work_ship':
-            total_worked_days += duration
-            if entry.location: # Location now stores country or ship name
-                work_days_by_location[entry.location] = work_days_by_location.get(entry.location, 0) + duration
+        if entry.entry_type == 'work_land':
+            total_work_land_days += duration
+            if entry.location: # Location stores country
+                work_land_days_by_country[entry.location] = work_land_days_by_country.get(entry.location, 0) + duration
+        elif entry.entry_type == 'work_ship':
+            total_work_ship_days += duration
+            # Ship work days are not added to work_land_days_by_country
         elif entry.entry_type == 'vacation':
             total_vacation_days += duration
         elif entry.entry_type == 'travel':
             total_travel_days += duration
 
     summaries = {
-        'total_worked_days': total_worked_days,
+        'total_work_land_days': total_work_land_days,
+        'total_work_ship_days': total_work_ship_days,
         'total_vacation_days': total_vacation_days,
         'total_travel_days': total_travel_days,
-        'work_days_by_location': work_days_by_location
+        'work_land_days_by_country': work_land_days_by_country
     }
 
     return render_template('index.html', entries=entries, summaries=summaries)

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -108,30 +108,31 @@
 
         <h2>Summary</h2>
         {% if summaries %}
-            <p><strong>Total Worked Days:</strong> {{ summaries.total_worked_days }}</p>
+            <p><strong>Total Worked Days - Land:</strong> {{ summaries.total_work_land_days }}</p>
+            <p><strong>Total Worked Days - Ship:</strong> {{ summaries.total_work_ship_days }}</p>
             <p><strong>Total Vacation Days:</strong> {{ summaries.total_vacation_days }}</p>
             <p><strong>Total Travel Days:</strong> {{ summaries.total_travel_days }}</p>
 
-            {% if summaries.work_days_by_location %}
-                <h3>Work Days by Location:</h3>
+            {% if summaries.work_land_days_by_country %}
+                <h3>Work Land Days by Country:</h3>
                 <table>
                     <thead>
                         <tr>
-                            <th>Location</th>
+                            <th>Country</th>
                             <th>Days</th>
                         </tr>
                     </thead>
                     <tbody>
-                        {% for location, days in summaries.work_days_by_location.items() %}
+                        {% for country, days in summaries.work_land_days_by_country.items() %}
                         <tr>
-                            <td>{{ location }}</td>
+                            <td>{{ country }}</td>
                             <td>{{ days }}</td>
                         </tr>
                         {% endfor %}
                     </tbody>
                 </table>
             {% else %}
-                <p>No work days recorded by location yet.</p>
+                <p>No Work Land days recorded by country yet.</p>
             {% endif %}
         {% else %}
             <p>No summary data available.</p>


### PR DESCRIPTION
This commit updates the application to provide more specific summaries for work days and a focused breakdown for land-based work.

Changes include:
- Backend:
    - Summary calculation logic in app/routes.py now differentiates totals for "Work Land" and "Work Ship" days.
    - The location-based breakdown is now specifically for "Work Land" entries, showing days per country.
- Frontend (index.html):
    - Summary display updated to show "Total Worked Days - Land" and "Total Worked Days - Ship".
    - The location breakdown table is now titled "Work Land Days by Country" and displays only relevant data.
- Documentation (README.md):
    - Updated "Features" and "How to Use" sections to reflect the new summary structure.